### PR TITLE
fix: return null when slug not found

### DIFF
--- a/src/utils/ComputedSlugs.ts
+++ b/src/utils/ComputedSlugs.ts
@@ -12,11 +12,10 @@ export const BlogSlugParam = (doc: LocalDocument) => {
 
 export const getPostFromSlug = async (params: PostProps['params']) => {
   const slug = params?.slug?.join('/');
-  const post = allBlogPosts.find((post) => post.slug === slug);
-
-  if (!post) {
-    null;
+  if (!slug) {
+    return null;
   }
 
-  return post;
+  const post = allBlogPosts.find((post) => post.slug === slug);
+  return post ?? null;
 };


### PR DESCRIPTION
## Summary
- prevent undefined post lookups by checking slug and returning `null`

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688fb51aebf883239afd24f812d430ad